### PR TITLE
Fix the export name for the ES6 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ You can either use the es6 module `dist/ready.js` or include the `iffe` from `di
 
 ```javascript
 // importing via es6 module syntax
-import { readyjs } from '../node_modules/readyjs/dist/ready.js'
+import { ready } from '../node_modules/readyjs/dist/ready.js'
 // used readyjs
-readyjs(function(){
+ready(function(){
     // your code here
 })
 


### PR DESCRIPTION
the export is named `ready`, not `readyjs`.